### PR TITLE
Fix to resolve #8

### DIFF
--- a/XRTK.Oculus/Packages/com.xrtk.oculus/OculusApi.cs
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/OculusApi.cs
@@ -943,6 +943,14 @@ namespace XRTK.Oculus
             }
         }
 
+        private class OVRControllerGamepadMac : OVRControllerBase
+        {
+            public OVRControllerGamepadMac()
+            {
+                controllerType = Controller.Gamepad;
+            }
+        }
+
         private class OVRControllerGamepadAndroid : OVRControllerBase
         {
             public OVRControllerGamepadAndroid()


### PR DESCRIPTION
## Overview

Fix to resolve #8

## Changes:

- Adds OVRControllerGamepadMac definition to resolve compile error.

## Notes:

Although Mac isn't a supported platform yet, MRTK should not break while working on the platform.
