### PR TITLE
Added Oculus Manifest generation tool for Quest

### DIFF
--- a/XRTK.Oculus/Packages/com.xrtk.oculus/Editor.meta
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8d7ec633fd58723429c98a9f03d71ac4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/AndroidManifest.OVRSubmission.xml
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/AndroidManifest.OVRSubmission.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    android:installLocation="auto">
+    <!-- Request the headset DoF mode -->
+    <application
+        android:allowBackup="false">
+        <activity
+            android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen"
+            android:configChanges="locale|fontScale|keyboard|keyboardHidden|mcc|mnc|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode"
+            android:launchMode="singleTask"
+            android:name="com.unity3d.player.UnityPlayerActivity"
+            android:excludeFromRecents="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+        <meta-data android:name="unityplayer.SkipPermissionsDialog" android:value="false" />
+    </application>
+</manifest>

--- a/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/AndroidManifest.OVRSubmission.xml.meta
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/AndroidManifest.OVRSubmission.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d7bb2f4f9eb606248b181412b03ad2fe
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/OculusManifestPreprocessor.cs
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/OculusManifestPreprocessor.cs
@@ -27,7 +27,7 @@ namespace XRTK.Oculus
 {
 	public class OculusManifestPreprocessor
 	{
-		[MenuItem("Mixed Reality Toolkit/Tools/Create store-compatible AndroidManifest.xml", false, 100000)]
+		[MenuItem("Mixed Reality Toolkit/Tools/Create Oculus Quest compatible AndroidManifest.xml", false, 100000)]
 		public static void GenerateManifestForSubmission()
 		{
 			var so = ScriptableObject.CreateInstance(typeof(OculusUpdaterStub));

--- a/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/OculusManifestPreprocessor.cs
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/OculusManifestPreprocessor.cs
@@ -1,0 +1,84 @@
+/************************************************************************************
+
+Copyright   :   Copyright (c) Facebook Technologies, LLC and its affiliates. All rights reserved.
+
+Licensed under the Oculus SDK License Version 3.4.1 (the "License");
+you may not use the Oculus SDK except in compliance with the License,
+which is provided at the time of installation or download, or which
+otherwise accompanies this software in either electronic or hard copy form.
+
+You may obtain a copy of the License at
+
+https://developer.oculus.com/licenses/sdk-3.4.1
+
+Unless required by applicable law or agreed to in writing, the Oculus SDK
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+************************************************************************************/
+
+using UnityEngine;
+using UnityEditor;
+using System.IO;
+
+namespace XRTK.Oculus
+{
+	public class OculusManifestPreprocessor
+	{
+		[MenuItem("Mixed Reality Toolkit/Tools/Create store-compatible AndroidManifest.xml", false, 100000)]
+		public static void GenerateManifestForSubmission()
+		{
+			var so = ScriptableObject.CreateInstance(typeof(OculusUpdaterStub));
+			var script = MonoScript.FromScriptableObject(so);
+			string assetPath = AssetDatabase.GetAssetPath(script);
+			string editorDir = Directory.GetParent(assetPath).FullName;
+			string srcFile = editorDir + "/AndroidManifest.OVRSubmission.xml";
+
+			if (!File.Exists(srcFile))
+			{
+				Debug.LogError("Cannot find Android manifest template for submission." +
+					" Please delete the OVR folder and reimport the Oculus Utilities.");
+				return;
+			}
+
+			string manifestFolder = Application.dataPath + "/Plugins/Android";
+
+			if (!Directory.Exists(manifestFolder))
+				Directory.CreateDirectory(manifestFolder);
+
+			string dstFile = manifestFolder + "/AndroidManifest.xml";
+
+			if (File.Exists(dstFile))
+			{
+				Debug.LogWarning("Cannot create Oculus store-compatible manifest due to conflicting file: \""
+					+ dstFile + "\". Please remove it and try again.");
+				return;
+			}
+
+			string manifestText = File.ReadAllText(srcFile);
+			int dofTextIndex = manifestText.IndexOf("<!-- Request the headset DoF mode -->");
+			if (dofTextIndex != -1)
+			{
+				//Forces Quest configuration.  Needs flip for Go/Gear viewer
+				string headTrackingFeatureText = "<uses-feature android:name=\"android.hardware.vr.headtracking\" android:version=\"1\" android:required=\"true\" />";
+				manifestText = manifestText.Insert(dofTextIndex, headTrackingFeatureText);
+			}
+			else
+			{
+				Debug.LogWarning("Manifest error: unable to locate headset DoF mode");
+			}
+
+			System.IO.File.WriteAllText(dstFile, manifestText);
+			AssetDatabase.Refresh();
+		}
+
+		[MenuItem("Mixed Reality Toolkit/Tools/Remove AndroidManifest.xml", false, 100001)]
+		public static void RemoveAndroidManifest()
+		{
+			AssetDatabase.DeleteAsset("Assets/Plugins/Android/AndroidManifest.xml");
+			AssetDatabase.Refresh();
+		}
+	}
+}

--- a/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/OculusManifestPreprocessor.cs.meta
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/OculusManifestPreprocessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6ab4fdf57978e5645a09d5cf8c540bee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/OculusUpdaterStub.cs
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/OculusUpdaterStub.cs
@@ -1,0 +1,32 @@
+/************************************************************************************
+
+Copyright   :   Copyright (c) Facebook Technologies, LLC and its affiliates. All rights reserved.
+
+Licensed under the Oculus SDK License Version 3.4.1 (the "License");
+you may not use the Oculus SDK except in compliance with the License,
+which is provided at the time of installation or download, or which
+otherwise accompanies this software in either electronic or hard copy form.
+
+You may obtain a copy of the License at
+
+https://developer.oculus.com/licenses/sdk-3.4.1
+
+Unless required by applicable law or agreed to in writing, the Oculus SDK
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+************************************************************************************/
+
+using UnityEngine;
+using System.Collections;
+
+namespace XRTK.Oculus
+{
+	public class OculusUpdaterStub : ScriptableObject
+	{
+		// Stub helper class to locate OVR Utilities Path through Unity Editor API.
+		// Required to be a standalone class in a separate file or else MonoScript.FromScriptableObject() returns an empty string path.
+	}
+}

--- a/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/OculusUpdaterStub.cs
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/OculusUpdaterStub.cs
@@ -24,9 +24,9 @@ using System.Collections;
 
 namespace XRTK.Oculus
 {
-	public class OculusUpdaterStub : ScriptableObject
+	internal class OculusUpdaterStub : ScriptableObject
 	{
-		// Stub helper class to locate OVR Utilities Path through Unity Editor API.
+		// Stub helper class to locate Utilities Path through Unity Editor API.
 		// Required to be a standalone class in a separate file or else MonoScript.FromScriptableObject() returns an empty string path.
 	}
 }

--- a/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/OculusUpdaterStub.cs.meta
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/OculusUpdaterStub.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1b3dd40c4b71a854cad4205ff9aba7db
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/XRTK.Oculus.Editor.asmdef
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/XRTK.Oculus.Editor.asmdef
@@ -1,0 +1,15 @@
+{
+    "name": "XRTK.Oculus.Editor",
+    "references": [],
+    "optionalUnityReferences": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": []
+}

--- a/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/XRTK.Oculus.Editor.asmdef.meta
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/XRTK.Oculus.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ec8b36c684415b5428fd4f43c0eb2593
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview

Added Oculus Manifest generation tool for Quest

For the Quest to detect the controllers properly, a custom AndroidManifest.xml file is required.  Ported the Oculus tools to enable this for XRTK projects.

In the future, this will be handled by the Build Window

## Changes:

- Fixes: #13 

## Notes

A manual task, users will need to use the "Mixed Reality Toolkit -> Tools" options to generate the manifest. Has safety features to check if there is an existing file and won't overwrite until it's removed.
