### PR TITLE
fixed some documentation

### DIFF
--- a/XRTK.Oculus/Packages/com.xrtk.oculus/Extensions/Vector3Extensions.cs
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/Extensions/Vector3Extensions.cs
@@ -8,7 +8,7 @@ namespace XRTK.Oculus.Extensions
     public static class Vector3Extensions
     {
         /// <summary>
-        /// Gets a <see cref="UnityEngine.Vector3"/> position from the <see cref="Posef"/>.
+        /// Gets a <see cref="UnityEngine.Vector3"/> position from the <see cref="OculusApi.Posef"/>.
         /// </summary>
         /// <param name="pose"></param>
         public static Vector3 GetPosePosition(this OculusApi.Posef pose)


### PR DESCRIPTION
## Overview

There was an ambiguous reference to `OculusApi.Posef` in `Vector3Extensions.cs`

## Changes:

- Fixes: documentation for ambiguous type.
