### PR TITLE
Remove obsolete SetupDefaultInteractions

### DIFF
--- a/XRTK.Oculus/Packages/com.xrtk.oculus/Controllers/BaseOculusController.cs
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/Controllers/BaseOculusController.cs
@@ -82,12 +82,6 @@ namespace XRTK.Oculus.Controllers
         /// <inheritdoc />
         public override MixedRealityInteractionMapping[] DefaultRightHandedInteractions => DefaultInteractions;
 
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            AssignControllerMappings(DefaultInteractions);
-        }
-
         private MixedRealityPose currentPointerPose = MixedRealityPose.ZeroIdentity;
         private MixedRealityPose lastControllerPose = MixedRealityPose.ZeroIdentity;
         private MixedRealityPose currentControllerPose = MixedRealityPose.ZeroIdentity;

--- a/XRTK.Oculus/Packages/com.xrtk.oculus/Controllers/OculusGoController.cs
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/Controllers/OculusGoController.cs
@@ -58,11 +58,5 @@ namespace XRTK.Oculus.Controllers
             new MixedRealityInteractionMapping("Button.DpadLeft", AxisType.Digital, "DpadLeft", DeviceInputType.ButtonPress),
             new MixedRealityInteractionMapping("Button.DpadRight", AxisType.Digital, "DpadRight", DeviceInputType.ButtonPress),
         };
-
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            AssignControllerMappings(controllerHandedness == Handedness.Left ? DefaultLeftHandedInteractions : DefaultRightHandedInteractions);
-        }
     }
 }

--- a/XRTK.Oculus/Packages/com.xrtk.oculus/Controllers/OculusRemoteController.cs
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/Controllers/OculusRemoteController.cs
@@ -30,11 +30,5 @@ namespace XRTK.Oculus.Controllers
             new MixedRealityInteractionMapping("Button.Start", AxisType.Digital, "Start", DeviceInputType.ButtonPress),
             new MixedRealityInteractionMapping("Button.Back", AxisType.Digital, "Back", DeviceInputType.ButtonPress),
         };
-
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            AssignControllerMappings(DefaultInteractions);
-        }
     }
 }

--- a/XRTK.Oculus/Packages/com.xrtk.oculus/Controllers/OculusTouchController.cs
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/Controllers/OculusTouchController.cs
@@ -65,11 +65,5 @@ namespace XRTK.Oculus.Controllers
             new MixedRealityInteractionMapping("Touch.SecondaryThumbRest Touch", AxisType.Digital, "RThumbRest", DeviceInputType.ThumbTouch),
             new MixedRealityInteractionMapping("Touch.SecondaryThumbRest Near Touch", AxisType.Digital, "RThumbRest", DeviceInputType.ThumbNearTouch)
         };
-
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            AssignControllerMappings(controllerHandedness == Handedness.Left ? DefaultLeftHandedInteractions : DefaultRightHandedInteractions);
-        }
     }
 }


### PR DESCRIPTION
## Overview

Removes the obsolete `SetupDefaultInteractions` in `BaseController` since it's not run anywhere anymore.