### PR TITLE
only print api version when playing

### DIFF
--- a/XRTK.Oculus/Packages/com.xrtk.oculus/OculusApi.cs
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/OculusApi.cs
@@ -40,7 +40,7 @@ namespace XRTK.Oculus
                             // Truncate unsupported trailing version info for System.Version. Original string is returned if not present.
                             pluginVersion = pluginVersion.Split('-')[0];
                             _version = new Version(pluginVersion);
-                            if (Debug.isDebugBuild)
+                            if (Debug.isDebugBuild && Application.isPlaying)
                             {
                                 Debug.Log($"Oculus API version detected was - [{_version.ToString()}]");
                             }


### PR DESCRIPTION
## Overview

Lots of spam in the console at edit time bc we query for the version each time we check if the oculus platform is valid.  This change just makes it so it only happens in play mode.