### PR TITLE
Fix deprecated hand tracking permission request ID warning

### DIFF
--- a/XRTK.Oculus/Packages/com.xrtk.oculus/Inspectors/BuildTools/OculusManifestPreprocessor.cs
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/Inspectors/BuildTools/OculusManifestPreprocessor.cs
@@ -64,7 +64,7 @@ namespace XRTK.Oculus.Inspector.Build
             if (dofTextIndex != -1)
             {
                 //Forces Quest configuration.  Needs flip for Go/Gear viewer
-                const string headTrackingFeatureText = "<uses-feature android:name=\"android.hardware.vr.headtracking\" android:version=\"1\" android:required=\"true\" />";
+                const string headTrackingFeatureText = "<uses-feature android:name=\"com.oculus.permission.HAND_TRACKING\" android:version=\"1\" android:required=\"true\" />";
                 manifestText = manifestText.Insert(dofTextIndex, headTrackingFeatureText);
             }
             else
@@ -81,8 +81,8 @@ namespace XRTK.Oculus.Inspector.Build
 
                 if (handTrackingEntryNeeded)
                 {
-                    string handTrackingFeatureText = $"<uses-feature android:name=\"oculus.software.handtracking\" android:required=\"{(handTrackingRequired ? "true" : "false")}\" />";
-                    const string handTrackingPermissionText = "<uses-permission android:name=\"oculus.permission.handtracking\" />";
+                    string handTrackingFeatureText = $"<uses-feature android:name=\"com.oculus.permission.HAND_TRACKING\" android:required=\"{(handTrackingRequired ? "true" : "false")}\" />";
+                    const string handTrackingPermissionText = "<uses-permission android:name=\"com.oculus.permission.HAND_TRACKING\" />";
 
                     manifestText = manifestText.Insert(handTrackingTextIndex, handTrackingPermissionText);
                     manifestText = manifestText.Insert(handTrackingTextIndex, handTrackingFeatureText);


### PR DESCRIPTION
## Overview

Fixes the warning that we are using a deprecated hand tracking permission ID in the manifest by updating to the new ID.