### PR TITLE
Fix exceptions when Oculus platform is unavailiable

### DIFF
--- a/XRTK.Oculus/Packages/com.xrtk.oculus/Runtime/Plugins/OculusApi.cs
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/Runtime/Plugins/OculusApi.cs
@@ -104,13 +104,20 @@ namespace XRTK.Oculus.Plugins
         internal static Controller connectedControllerTypes = Controller.None;
 
         /// <summary>
-        /// Oculus API Initialised check
+        /// Oculus API Initialized check
         /// </summary>
         public static bool Initialized
         {
             get
             {
-                return ovrp_GetInitialized() == Bool.True;
+                try
+                {
+                    return ovrp_GetInitialized() == Bool.True;
+                }
+                catch
+                {
+                    return false;
+                }
             }
         }
 


### PR DESCRIPTION
## Overview

Some platforms throw an exception when trying to check if the Oculus platform is enabled