### PR TITLE
Add platform level to path

### DIFF
--- a/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/BuildTools/OculusManifestPreprocessor.cs
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/BuildTools/OculusManifestPreprocessor.cs
@@ -28,7 +28,7 @@ namespace XRTK.Oculus.Editor.Build
 {
     public class OculusManifestPreprocessor
     {
-        [MenuItem("Mixed Reality Toolkit/Tools/Create Oculus Quest compatible AndroidManifest.xml", false, 100000)]
+        [MenuItem("Mixed Reality Toolkit/Tools/Oculus/Create Oculus Quest compatible AndroidManifest.xml", false, 100000)]
         public static void GenerateManifestForSubmission()
         {
             var so = ScriptableObject.CreateInstance(typeof(OculusPathFinder));
@@ -99,7 +99,7 @@ namespace XRTK.Oculus.Editor.Build
             AssetDatabase.Refresh();
         }
 
-        [MenuItem("Mixed Reality Toolkit/Tools/Remove AndroidManifest.xml", false, 100001)]
+        [MenuItem("Mixed Reality Toolkit/Tools/Oculus/Remove AndroidManifest.xml", false, 100001)]
         public static void RemoveAndroidManifest()
         {
             AssetDatabase.DeleteAsset("Assets/Plugins/Android/AndroidManifest.xml");


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

As XRTK grows it's important available tools and menu items are organized. Moved the Oculus specific tooling to an Oculus group. This does add one level down the hierarchy but it's clear that these tools are for use with Oculus only.