### PR TITLE
Fix duplicate hand tracking entry in manifest

### DIFF
--- a/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/BuildTools/AndroidManifest.OVRSubmission.xml
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/BuildTools/AndroidManifest.OVRSubmission.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     android:installLocation="auto">
   <!-- Request the headset DoF mode -->
-  <!-- Request the headset handtracking mode -->
+  <!-- Request the headset hand tracking mode -->
   <application
       android:label="@string/app_name"
       android:icon="@mipmap/app_icon">

--- a/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/BuildTools/OculusManifestPreprocessor.cs
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/BuildTools/OculusManifestPreprocessor.cs
@@ -34,7 +34,7 @@ namespace XRTK.Oculus.Editor.Build
         private const string TEMPLATE_MANIFEST_FILE_NAME = "AndroidManifest.OVRSubmission.xml";
         private const string OUTPUT_MANIFEST_FILE_NAME = "AndroidManifest.xml";
         private const string DOF_MODE_MARKER = "<!-- Request the headset DoF mode -->";
-        private const string HAND_TRACKING_MODE_MARKER = "<!-- Request the headset handtracking mode -->";
+        private const string HAND_TRACKING_MODE_MARKER = "<!-- Request the headset hand tracking mode -->";
 
         private static string ManifestFolder => $"{Application.dataPath}/Plugins/Android";
 
@@ -55,7 +55,7 @@ namespace XRTK.Oculus.Editor.Build
 
             if (!File.Exists(srcFile))
             {
-                Debug.LogError("Cannot find Android manifest template for submission. Please delete the OVR folder and reimport the Oculus Utilities.");
+                Debug.LogError("Cannot find Android manifest template for submission. Please reimport the XRTK.Oculus package.");
                 return;
             }
 


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Fixes the issue with the Oculus manifest generator.

## Changes

- Added a link to some manifest docs to the class doc
- Fixed the issue where a hand tracking is requested twice in the manifest

- Fixes: #75 
