### PR TITLE
removed windows platform overrides for oculus platform

### DIFF
--- a/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/BuildPipeline/OculusBuildInfo.cs
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/Editor/BuildPipeline/OculusBuildInfo.cs
@@ -4,7 +4,6 @@
 using System.Linq;
 using UnityEditor;
 using UnityEditor.Build.Reporting;
-using UnityEngine;
 using XRTK.Attributes;
 using XRTK.Interfaces;
 using XRTK.Oculus;

--- a/XRTK.Oculus/Packages/com.xrtk.oculus/Runtime/OculusPlatform.cs
+++ b/XRTK.Oculus/Packages/com.xrtk.oculus/Runtime/OculusPlatform.cs
@@ -20,8 +20,7 @@ namespace XRTK.Oculus
         /// <inheritdoc />
         public override IMixedRealityPlatform[] PlatformOverrides { get; } =
         {
-            new AndroidPlatform(),
-            new WindowsStandalonePlatform()
+            new AndroidPlatform()
         };
 
 #if UNITY_EDITOR
@@ -31,9 +30,7 @@ namespace XRTK.Oculus
         /// <inheritdoc />
         public override UnityEditor.BuildTarget[] ValidBuildTargets { get; } =
         {
-            UnityEditor.BuildTarget.Android,
-            UnityEditor.BuildTarget.StandaloneWindows64,
-            UnityEditor.BuildTarget.StandaloneWindows
+            UnityEditor.BuildTarget.Android
         };
 #endif // UNITY_EDITOR
     }


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->
This should fix the issue with the CI/CD builds trying to build oculus for windows standalone. 
